### PR TITLE
TradeTracker DateTo should be inclusive

### DIFF
--- a/Oara/Network/Publisher/TradeTracker.php
+++ b/Oara/Network/Publisher/TradeTracker.php
@@ -92,8 +92,9 @@ class Oara_Network_Publisher_TradeTracker extends Oara_Network {
 	public function getTransactionList($merchantList = null, Zend_Date $dStartDate = null, Zend_Date $dEndDate = null, $merchantMap = null) {
 		$totalTransactions = array();
 
-		$options = array('registrationDateFrom'	 => $dStartDate->toString('yyyy-MM-dd'),
-			'registrationDateTo'	 => $dEndDate->toString('yyyy-MM-dd'),
+		$options = array(
+			'registrationDateFrom'	 => $dStartDate->toString('yyyy-MM-dd'),
+			'registrationDateTo'	 => $dEndDate->addDay(1)->toString('yyyy-MM-dd'),
 		);
 		$affiliateSitesList = $this->_apiClient->getAffiliateSites();
 		foreach ($affiliateSitesList as $affiliateSite) {


### PR DESCRIPTION
`TradeTracker::getTransactionList` does not return transactions on the day of endDate. Comments in base class say that the endDate should be included. This PR fixes that bug.

```
     /**
     *
     * Get the transactions for the network and the merchants selected for the date given
     * @param array $merchantList - array with the merchants we want to retrieve the data from
     * @param Zend_Date $dStartDate - start date (included)
     * @param Zend_Date $dEndDate - end date (included)
     */
    public function getTransactionList($merchantList, Zend_Date $dStartDate, Zend_Date $dEndDate, $merchantMap = null) {
        $result = array();
        return $result;
    }
```
